### PR TITLE
Fix best match

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,10 @@
   ],
   "author": "Leonardo Carvalho",
   "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/leodsc/string-similarity-alg"
+  },
   "devDependencies": {
     "@jest/globals": "^29.7.0",
     "@types/jest": "^29.5.11",

--- a/src/algorithms/levenshtein.ts
+++ b/src/algorithms/levenshtein.ts
@@ -41,7 +41,7 @@ export class Levenshtein implements SimilarityAlgorithm {
   };
 
   compareOneToMany = (target: string, compare: string[]) => {
-    const ssr = new StringSimilarityResults();
+    const ssr = new StringSimilarityResults("ascending");
     for (const c of compare) {
       const result = this.compare(target, c);
       ssr.add(target, c, result);

--- a/src/string-similarity-result.ts
+++ b/src/string-similarity-result.ts
@@ -24,6 +24,16 @@ interface StringSimilarityResult {
 
 export class StringSimilarityResults implements StringSimilarityResult {
   private similarities = new Map<string, Match[]>();
+  // Multiplied by matches to toggle sorting from descending (1) to ascending (-1)
+  private orderMultiplier: 1 | -1;
+
+  /**
+   * 
+   * @param order How to sort similarities. Is "descending" by default, which will try to minimize similarity. Conversely, "ascending" will maximize similarity
+   */
+  constructor(order: "ascending" | "descending" = "descending") {
+    this.orderMultiplier = order === "descending" ? 1 : -1;
+  }
 
   add(s1: string, s2: string, similarity: number) {
     if (!this.similarities.has(s1)) {
@@ -52,7 +62,7 @@ export class StringSimilarityResults implements StringSimilarityResult {
 
       let currentBestResult = matches[0];
       matches.forEach((match) => {
-        if (match.match > currentBestResult.match) {
+        if (match.match * this.orderMultiplier > currentBestResult.match * this.orderMultiplier) {
           currentBestResult = match;
         }
       });
@@ -73,7 +83,7 @@ export class StringSimilarityResults implements StringSimilarityResult {
       }
 
       matches.sort((curr, next) => {
-        if (curr.match > next.match) {
+        if (curr.match * this.orderMultiplier < next.match * this.orderMultiplier) {
           return Compare.LESSER_OR_EQUAL;
         }
 

--- a/src/string-similarity.ts
+++ b/src/string-similarity.ts
@@ -1,8 +1,10 @@
-import { JaroSimilarity, jaroSimilarity } from "./algorithms/jaro-similarity";
-import { JaroWinkler, jaroWinkler } from "./algorithms/jaro-winkler";
+import { JaroSimilarity } from "./algorithms/jaro-similarity";
+import { JaroWinkler } from "./algorithms/jaro-winkler";
+import { Levenshtein } from "./algorithms/levenshtein";
+import { SorensenDice } from "./algorithms/sorensen-dice";
 import { StringSimilarityResults } from "./string-similarity-result";
 
-type SimilarityAlgorithmsNames = "jaro-winkler" | "jaro-similarity" | "dice-coefficient";
+type SimilarityAlgorithmsNames = "jaro-winkler" | "jaro-similarity" | "dice-coefficient" | "levenshtein";
 
 export interface SimilarityAlgorithm {
   compare: (target: string, compare: string) => number
@@ -17,6 +19,10 @@ class StringSimilarity {
         return new JaroSimilarity();
       case "jaro-winkler":
         return new JaroWinkler();
+      case "dice-coefficient":
+        return new SorensenDice();
+      case "levenshtein":
+        return new Levenshtein();
       default:
         throw new Error("Unknown algorithm");
     }

--- a/src/test/algorithms.test.ts
+++ b/src/test/algorithms.test.ts
@@ -1,4 +1,4 @@
-import { jaroSimilarity, jaroWinkler } from "../index";
+import { jaroSimilarity, jaroWinkler, levenshtein, sorensenDice } from "../index";
 
 describe("Algorithms", () => {
   describe("Jaro-Winkler", () => {
@@ -48,5 +48,14 @@ describe("Algorithms", () => {
       const result = jaroSimilarity.compare("dixon", "dicksonx");
       expect(result).toBeCloseTo(0.766);
     });
-  })
+  });
+
+  describe("Levenshtein", () => {
+    it("find best match", () => {
+      const target = "qwertyuiop";
+      const mostSimilar = levenshtein.compareOneToMany(target, ["qwertyuiop", "asdfghjkl"]).bestMatch()[target];
+      expect(mostSimilar.value).toEqual(target);
+      expect(mostSimilar.match).toEqual(0);
+    });
+  });
 })


### PR DESCRIPTION
I noticed that when running the Levenshtein algorithm, it actually returned the worst match because the other algorithms have a higher similarity the more similar they are, but since Levenshtein is a distance algorithm, it has a lower value for more similar items

Also changed:
- Added the remaining 2 sorters to the switch statement of default import
- Add repo link, so easier to find from NPM