### PR TITLE
Add git information to show on npm page

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,14 @@
     "publish:minor": "pnpm build && npm version minor && npm publish",
     "publish:major": "pnpm build && npm version major && npm publish"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/leodsc/string-similarity-alg.git"
+  },
+  "bugs": {
+    "url": "https://github.com/leodsc/string-similarity-alg/issues"
+  },
+  "homepage": "https://github.com/leodsc/string-similarity-alg#readme",
   "keywords": [
     "string",
     "similarity",


### PR DESCRIPTION
Use the following in the package.json and publish it to npm, so that they display your github as a link inside of the npm package displayment